### PR TITLE
Use of SHA2 for reduced cycle count

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1035,7 +1035,7 @@ name = "chacha-program"
 version = "0.1.0"
 dependencies = [
  "chacha-lib",
- "sha3",
+ "sha2",
  "sp1-zkvm",
 ]
 
@@ -1049,7 +1049,7 @@ dependencies = [
  "hex",
  "serde",
  "serde_json",
- "sha3",
+ "sha2",
  "sp1-build",
  "sp1-sdk",
  "tracing",
@@ -4015,8 +4015,7 @@ dependencies = [
 [[package]]
 name = "sha2"
 version = "0.10.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "793db75ad2bcafc3ffa7c68b215fee268f537982cd901d132f89c6343f3a3dc8"
+source = "git+https://github.com/sp1-patches/RustCrypto-hashes?tag=patch-sha2-0.10.8-sp1-4.0.0#1f224388fdede7cef649bce0d63876d1a9e3f515"
 dependencies = [
  "cfg-if",
  "cpufeatures",
@@ -4026,7 +4025,8 @@ dependencies = [
 [[package]]
 name = "sha3"
 version = "0.10.8"
-source = "git+https://github.com/sp1-patches/RustCrypto-hashes?tag=patch-sha3-0.10.8-sp1-4.0.0#8f6d303c0861ba7e5adcc36207c0f41fe5edaabc"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75872d278a8f37ef87fa0ddbda7802605cb18344497949862c0d4dcb291eba60"
 dependencies = [
  "digest 0.10.7",
  "keccak",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,11 +4,11 @@ resolver = "2"
 
 [workspace.dependencies]
 hex = "0.4"
-sha3 = "=0.10.8"
+sha2 = "=0.10.8"
 sp1-zkvm = "4.0.0"
 chacha20 = "0.9.1"
 
 chacha-lib = { path = "lib", default-features = false }
 
 [patch.crates-io]
-sha3-v0-10-8 = { git = "https://github.com/sp1-patches/RustCrypto-hashes", package = "sha3", tag = "patch-sha3-0.10.8-sp1-4.0.0" }
+sha2-v0-10-8 = { git = "https://github.com/sp1-patches/RustCrypto-hashes", package = "sha2", tag = "patch-sha2-0.10.8-sp1-4.0.0" }

--- a/program/Cargo.toml
+++ b/program/Cargo.toml
@@ -4,7 +4,7 @@ name = "chacha-program"
 edition = "2021"
 
 [dependencies]
-sha3.workspace = true
+sha2.workspace = true
 sp1-zkvm.workspace = true
 
 chacha-lib.workspace = true

--- a/program/src/main.rs
+++ b/program/src/main.rs
@@ -1,7 +1,7 @@
 #![no_main]
 sp1_zkvm::entrypoint!(main);
 
-use sha3::{Digest, Sha3_256};
+use sha2::{Digest, Sha256};
 
 use chacha_lib::chacha;
 
@@ -17,7 +17,10 @@ pub fn main() {
     // The EVM has KECCAK256 opcode (Solidity `keccak256()`)
     // KECCAK256 = 30 gas base & per 32 bytes word = 6 gas
     // So SHA3 is most performat to choose for EVM.
-    let plaintext_hash = Sha3_256::digest(buffer.as_slice());
+    //
+    // BUT the cycle count is significantly higher for SHA3 (even accelerated)
+    // so we choose to use SHA2, for slightly higher on chain verification gas costs.
+    let plaintext_hash = Sha256::digest(buffer.as_slice());
     // Hash plaintext & commit
     sp1_zkvm::io::commit_slice(&plaintext_hash); // 32 bytes
 

--- a/script/Cargo.toml
+++ b/script/Cargo.toml
@@ -19,7 +19,7 @@ serde = { version = "1.0.200", default-features = false, features = ["derive"] }
 clap = { version = "4.0", features = ["derive", "env"] }
 tracing = "0.1.40"
 hex.workspace = true
-sha3.workspace = true
+sha2.workspace = true
 dotenv = "0.15.0"
 
 chacha-lib = { workspace = true, features = ["std"] }

--- a/script/src/bin/main.rs
+++ b/script/src/bin/main.rs
@@ -12,7 +12,7 @@
 
 use clap::Parser;
 use hex::FromHex;
-use sha3::{Digest, Sha3_256};
+use sha2::{Digest, Sha256};
 use sp1_sdk::{include_elf, ProverClient, SP1Stdin};
 
 use chacha_lib::chacha;
@@ -73,13 +73,13 @@ fn main() {
         println!("Program executed successfully.");
 
         // Read the output.
-        // - sha3 hash = 32 bytes
+        // - sha2 hash = 32 bytes
         // - ciphertext = encrypted bytes
         let output = output.to_vec();
         let (output_hash_plaintext, output_ciphertext) = output.split_at(32);
 
         // Check against the input
-        let input_plaintext_digest = Sha3_256::digest(input_plaintext);
+        let input_plaintext_digest = Sha256::digest(input_plaintext);
         println!(
             "Input -> plaintext hash: 0x{}",
             chacha_lib::bytes_to_hex(&input_plaintext_digest)
@@ -89,7 +89,7 @@ fn main() {
             chacha_lib::bytes_to_hex(output_hash_plaintext)
         );
 
-        let ciphertext_digest = Sha3_256::digest(output_ciphertext);
+        let ciphertext_digest = Sha256::digest(output_ciphertext);
         println!(
             "zkVM -> ciphertext hash: 0x{}",
             chacha_lib::bytes_to_hex(&ciphertext_digest)


### PR DESCRIPTION
For the example input we get the following with `cargo r -r -- --execute` :
```
SHA2_256
Number of cycles: 157,700,235

SHA3_256
Number of cycles: 237,126,505
```

The downside is SHA2 is less performant in EVM. So we may want to consider what is better cost wise overall, assuming the very significant added overhead of running SHA3 in cycles is practically possible with other considerations in mind (like speed, etc.)

---

A note from [chatgpt](https://chatgpt.com/share/e/67f06d86-faa8-8001-a99c-9b4945c8ab38):

> SHA-2 (e.g., SHA-256) is likely to be significantly cheaper in cycles than SHA-3 (e.g., Keccak) inside a zkVM—even when using optimized or patched crates for both. Here's a breakdown of why:
> 🔬 Hash Cost Differences in zkVMs (SP1, RISC Zero, etc.)
> 1. Arithmetic Complexity
> 
>     SHA-2 (SHA-256):
> 
>         Built with bitwise operations: AND, OR, XOR, rotations, additions modulo 232232.
> 
>         These operations map relatively well to zk-friendly field arithmetic and can often be "compressed" with custom gates or lookup tables.
> 
>     SHA-3 (Keccak):
> 
>         Keccak uses a sponge construction with 1600-bit state and more complex permutations (θ, ρ, π, χ, ι) involving non-linear operations over large word sizes (64-bit lanes).
> 
>         These are much more expensive to express as R1CS or AIR constraints.
> 
> ✅ Result: SHA-3 typically consumes 2–3x more constraints/cycles than SHA-2 in proof systems unless very specialized optimizations are used.